### PR TITLE
Removes discord text in title bar

### DIFF
--- a/src/base/_titlebar.scss
+++ b/src/base/_titlebar.scss
@@ -7,8 +7,6 @@
     height: 12px;
     margin: 5px 10px 0 0;
   
-    &:hover .winButton-3UMjdg {
-      opacity: 1;
     }
 }
   

--- a/src/base/_titlebar.scss
+++ b/src/base/_titlebar.scss
@@ -1,0 +1,15 @@
+/* discord text on top left */
+.wordmarkWindows-2dq6rw {
+    opacity: 0;
+  }
+  
+  .withFrame-2dL45i {
+    height: 12px;
+    margin: 5px 10px 0 0;
+  
+    &:hover .winButton-3UMjdg {
+      opacity: 1;
+    }
+}
+  
+

--- a/src/source.scss
+++ b/src/source.scss
@@ -1,4 +1,5 @@
 //? Base
+@forward "base/titlebar";
 @forward 'base/fonts';
 @forward 'base/info';
 @forward 'base/input';


### PR DESCRIPTION
We got some copy and paste action goin on here ;)
I made the title bar a bit thinner as well, I thought it looked weird at default **thiccness**

# beFOR thinning (thicc)
![image](https://user-images.githubusercontent.com/85663797/182613368-f8b6b3d7-a43b-43cd-b534-2744a847ef28.png)
# After thinning (not thicc 😔)
![image](https://user-images.githubusercontent.com/85663797/182613639-cee17719-4e1d-42e6-ba69-f2fec256f779.png)

I didn't add the wolf icon thing i made in my pr for main lavender because I wasn't sure if you would want it here, but i can add it in this pr if you'd like :D